### PR TITLE
Configuration for inclusion in Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [ObliviousHTTP, ObliviousX]


### PR DESCRIPTION
Motivation:

Swift Package Index inclusion will help visibility.

Modifications:

Add an .spi.yml file.

Result:

Swift Package Index should build correct docs