### PR TITLE
Remove mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,0 @@
-Cory Benfield <cbenfield@apple.com> <lukasa@apple.com>
-Peter Adams <pp_adams@apple.com> <63288215+PeterAdams-A@users.noreply.github.com>


### PR DESCRIPTION
Motivation:

Contributor tracking is now just going to be left to git directly.

Modifications:

Remove mailmap file.

Result:

Less cluttered repo