### PR TITLE
Making BHTTPSerializer compliant to known-length messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ dependencies: [
 ### Binary HTTP Encoding
 
 To serialise binary HTTP messages use `BHTTPSerializer.serialize(message, buffer)`.
+As defined in [RFC9292](https://www.rfc-editor.org/rfc/rfc9292),  you can choose to use either the known-length format or an indeterminate-length format. This choice can be configured during the initialization of the serializer by passing the desired type: `BHTTPSerializer(type: .knownLength)`.
 
-To deserialise binary HTTP messages use `BHTTPParser`, adding received data with `append()`, then calling `completeBodyRecieved()`.  The read the message parts received call `nextMessage()`.
+To deserialise binary HTTP messages use `BHTTPParser`, adding received data with `append()`, then calling `completeBodyReceived()`.  The read the message parts received call `nextMessage()`.
 
 ### Oblivious Encapsulation
 

--- a/Sources/ObliviousHTTP/Errors.swift
+++ b/Sources/ObliviousHTTP/Errors.swift
@@ -44,13 +44,30 @@ public struct ObliviousHTTPError: Error, Hashable {
         Self.init(backing: .truncatedEncoding(reason: reason))
     }
 
-    /// Create an error indicating that parsing faileud due to an unexpected HTTP status code.
+    /// Create an error indicating that parsing failed due to an unexpected HTTP status code.
     /// - Parameter status: The status code encountered.
     /// - Returns: An Error representing this failure.
     @inline(never)
     public static func invalidStatus(status: Int) -> ObliviousHTTPError {
         Self.init(backing: .invalidStatus(status: status))
     }
+
+    /// Create an error indicating that serializing failed due to an unexpected HTTP section.
+    /// - Parameter status: The state encountered.
+    /// - Returns: An Error representing this failure.
+    @inline(never)
+    public static func unexpectedHTTPMessageSection(state: String) -> ObliviousHTTPError {
+        Self.init(backing: .unexpectedHTTPMessageSection(state: "\(state) section was not expected."))
+    }
+
+    /// Create an error indicating that serializing failed due to an unsupported option.
+    /// - Parameter status: The unsupported option details.
+    /// - Returns: An Error representing this failure.
+    @inline(never)
+    public static func unsupportedOption(reason: String) -> ObliviousHTTPError {
+        Self.init(backing: .unsupportedOption(reason: reason))
+    }
+
 }
 
 extension ObliviousHTTPError {
@@ -59,5 +76,7 @@ extension ObliviousHTTPError {
         case invalidFieldSection(reason: String)
         case truncatedEncoding(reason: String)
         case invalidStatus(status: Int)
+        case unexpectedHTTPMessageSection(state: String)
+        case unsupportedOption(reason: String)
     }
 }

--- a/Tests/ObliviousHTTPTests/BHTTPSerializerTests.swift
+++ b/Tests/ObliviousHTTPTests/BHTTPSerializerTests.swift
@@ -30,12 +30,12 @@ final class BHTTPSerializerTests: XCTestCase {
             .end(nil),
         ]
 
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .server)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .server)
 
         for message in request {
-            serializer.serialize(.request(message), into: &buffer)
+            try serializer.serialize(.request(message), into: &buffer)
         }
 
         parser.append(buffer)
@@ -53,6 +53,105 @@ final class BHTTPSerializerTests: XCTestCase {
         XCTAssertEqual(expectedRequest, received)
     }
 
+    func testSimpleGetRequestRoundTripsWithKnownLengthSerializer() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
+            ("host", "www.example.com"),
+            ("accept-language", "en, mi"),
+        ])
+        let request: [HTTPClientRequestPart] = [
+            .head(.init(version: .http1_1, method: .GET, uri: "/example", headers: expectedHeaders)),
+            .end(nil),
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer(type: .knownLength)
+        var parser = BHTTPParser(role: .server)
+
+        for message in request {
+            try serializer.serialize(.request(message), into: &buffer)
+        }
+
+        parser.append(buffer)
+        parser.completeBodyReceived()
+        var received: [HTTPServerRequestPart] = []
+
+        while let next = try parser.nextMessage(), case .request(let request) = next {
+            received.append(request)
+        }
+
+        let expectedRequest: [HTTPServerRequestPart] = [
+            .head(.init(version: .http1_1, method: .GET, uri: "/example", headers: expectedHeaders)),
+            .end(nil),
+        ]
+        XCTAssertEqual(expectedRequest, received)
+    }
+
+    func testSerializerThrowsForMultipleHeadPartsInRequest() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
+            ("host", "www.example.com"),
+            ("accept-language", "en, mi"),
+        ])
+        let request: [HTTPClientRequestPart] = [
+            .head(.init(version: .http1_1, method: .GET, uri: "/example", headers: expectedHeaders)),
+            .head(.init(version: .http1_1, method: .GET, uri: "/example", headers: expectedHeaders)),
+            .end(nil),
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+
+        var didThrowError = false
+
+        for message in request {
+            do {
+                try serializer.serialize(.request(message), into: &buffer)
+            } catch {
+                didThrowError = true
+                XCTAssertNotNil(error, "Chunk section was not expected.")
+                break
+            }
+        }
+
+        XCTAssertTrue(didThrowError, "Expected serializer to throw an error because the request has 2 heads part.")
+    }
+
+    func testSerializerThrowsForOutOfOrderRequestParts() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
+            ("host", "www.example.com"),
+            ("accept-language", "en, mi"),
+            ("content-length", "5"),
+        ])
+        let request: [HTTPClientRequestPart] = [
+            .body(.byteBuffer(.init(string: "he"))),
+            .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
+            .body(.byteBuffer(.init(string: "llo"))),
+            .end(nil),
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+
+        var didThrowError = false
+
+        for message in request {
+            do {
+                try serializer.serialize(.request(message), into: &buffer)
+            } catch {
+                didThrowError = true
+                XCTAssertNotNil(error, "Header section was not expected.")
+                break
+            }
+        }
+
+        XCTAssertTrue(
+            didThrowError,
+            "Expected serializer to throw an error because the request has out of order parts."
+        )
+    }
+
     func testSimplePOSTRequestRoundTrips() throws {
         let expectedHeaders = HTTPHeaders([
             ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
@@ -67,12 +166,12 @@ final class BHTTPSerializerTests: XCTestCase {
             .end(nil),
         ]
 
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .server)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .server)
 
         for message in request {
-            serializer.serialize(.request(message), into: &buffer)
+            try serializer.serialize(.request(message), into: &buffer)
         }
 
         parser.append(buffer)
@@ -87,6 +186,44 @@ final class BHTTPSerializerTests: XCTestCase {
             .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
             .body(.init(string: "he")),
             .body(.init(string: "llo")),
+            .end(nil),
+        ]
+        XCTAssertEqual(expectedRequest, received)
+    }
+
+    func testSimplePOSTRequestRoundTripsWithKnownLengthSerialiser() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
+            ("host", "www.example.com"),
+            ("accept-language", "en, mi"),
+            ("content-length", "5"),
+        ])
+        let request: [HTTPClientRequestPart] = [
+            .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
+            .body(.byteBuffer(.init(string: "he"))),
+            .body(.byteBuffer(.init(string: "llo"))),
+            .end(nil),
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer(type: .knownLength)
+        var parser = BHTTPParser(role: .server)
+
+        for message in request {
+            try serializer.serialize(.request(message), into: &buffer)
+        }
+
+        parser.append(buffer)
+        parser.completeBodyReceived()
+        var received: [HTTPServerRequestPart] = []
+
+        while let next = try parser.nextMessage(), case .request(let request) = next {
+            received.append(request)
+        }
+
+        let expectedRequest: [HTTPServerRequestPart] = [
+            .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
+            .body(.init(string: "hello")),
             .end(nil),
         ]
         XCTAssertEqual(expectedRequest, received)
@@ -110,12 +247,12 @@ final class BHTTPSerializerTests: XCTestCase {
             .end(expectedTrailers),
         ]
 
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .server)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .server)
 
         for message in request {
-            serializer.serialize(.request(message), into: &buffer)
+            try serializer.serialize(.request(message), into: &buffer)
         }
 
         parser.append(buffer)
@@ -135,6 +272,49 @@ final class BHTTPSerializerTests: XCTestCase {
         XCTAssertEqual(expectedRequest, received)
     }
 
+    func testSimplePOSTRequestWithTrailersRoundTripsAndKnownLengthSerializer() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("user-agent", "curl/7.16.3 libcurl/7.16.3 OpenSSL/0.9.7l zlib/1.2.3"),
+            ("host", "www.example.com"),
+            ("accept-language", "en, mi"),
+            ("content-length", "5"),
+        ])
+        let expectedTrailers = HTTPHeaders([
+            ("foo", "bar"),
+            ("froo", "brar"),
+        ])
+        let request: [HTTPClientRequestPart] = [
+            .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
+            .body(.byteBuffer(.init(string: "he"))),
+            .body(.byteBuffer(.init(string: "llo"))),
+            .end(expectedTrailers),
+            .end(nil),
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer(type: .knownLength)
+        var parser = BHTTPParser(role: .server)
+
+        for message in request {
+            try serializer.serialize(.request(message), into: &buffer)
+        }
+
+        parser.append(buffer)
+        parser.completeBodyReceived()
+        var received: [HTTPServerRequestPart] = []
+
+        while let next = try parser.nextMessage(), case .request(let request) = next {
+            received.append(request)
+        }
+
+        let expectedRequest: [HTTPServerRequestPart] = [
+            .head(.init(version: .http1_1, method: .POST, uri: "/example", headers: expectedHeaders)),
+            .body(.init(string: "hello")),
+            .end(expectedTrailers)
+        ]
+        XCTAssertEqual(expectedRequest, received)
+    }
+
     func testSimple201ResponseRoundTrips() throws {
         let expectedHeaders = HTTPHeaders([
             ("server", "apache"),
@@ -145,12 +325,12 @@ final class BHTTPSerializerTests: XCTestCase {
             .end(nil),
         ]
 
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .client)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .client)
 
         for message in response {
-            serializer.serialize(.response(message), into: &buffer)
+            try serializer.serialize(.response(message), into: &buffer)
         }
 
         parser.append(buffer)
@@ -179,13 +359,12 @@ final class BHTTPSerializerTests: XCTestCase {
             .body(.byteBuffer(ByteBuffer(string: "hello"))),
             .end(nil),
         ]
-
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .client)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .client)
 
         for message in response {
-            serializer.serialize(.response(message), into: &buffer)
+            try serializer.serialize(.response(message), into: &buffer)
         }
 
         parser.append(buffer)
@@ -220,12 +399,54 @@ final class BHTTPSerializerTests: XCTestCase {
             .end(expectedTrailers),
         ]
 
-        let serializer = BHTTPSerializer()
-        var parser = BHTTPParser(role: .client)
         var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer()
+        var parser = BHTTPParser(role: .client)
 
         for message in response {
-            serializer.serialize(.response(message), into: &buffer)
+            try serializer.serialize(.response(message), into: &buffer)
+        }
+
+        parser.append(buffer)
+        parser.completeBodyReceived()
+        var received: [HTTPClientResponsePart] = []
+
+        while let next = try parser.nextMessage(), case .response(let response) = next {
+            received.append(response)
+        }
+
+        let expectedResponse: [HTTPClientResponsePart] = [
+            .head(.init(version: .http1_1, status: .noContent, headers: expectedHeaders)),
+            .body(ByteBuffer(string: "hello")),
+            .end(expectedTrailers),
+        ]
+        XCTAssertEqual(expectedResponse, received)
+    }
+
+
+    func testSimple200ResponseWithBodyAndTrailersRoundTripsAndKnownLengthSerializer() throws {
+        let expectedHeaders = HTTPHeaders([
+            ("server", "apache"),
+            ("other-header", "its value"),
+            ("content-length", "5"),
+        ])
+        let expectedTrailers = HTTPHeaders([
+            ("foo", "bar"),
+            ("froo", "brar"),
+        ])
+        let response: [HTTPServerResponsePart] = [
+            .head(.init(version: .http1_1, status: .noContent, headers: expectedHeaders)),
+            .body(.byteBuffer(ByteBuffer(string: "hello"))),
+            .end(expectedTrailers),
+            .end(nil)
+        ]
+
+        var buffer = ByteBuffer()
+        var serializer = BHTTPSerializer(type: .knownLength)
+        var parser = BHTTPParser(role: .client)
+
+        for message in response {
+            try serializer.serialize(.response(message), into: &buffer)
         }
 
         parser.append(buffer)


### PR DESCRIPTION
Motivation:

As defined in [RFC9292](https://www.rfc-editor.org/rfc/rfc9292),  you can choose to use either the known-length format or an indeterminate-length format. The purpose of this PR is to give the possibility for users to use the known-length format.

Modifications:

    - Finite State Machine (FSM): Added an FSM to the serializer to define allowed state transitions. This prevents invalid sequences, such as having a Body HTTP Part followed by a Header HTTP Part.
    - BHTTPSerializer: Introduced a flag within BHTTPSerializer to determine whether the known-length or indeterminate-length format will be used.
    - Serialization of Known-Length Sections: Added methods to BHTTPSerializer specifically for serializing known-length sections.
    - Unit-tests: I updated unit tests to cover scenarios where we have out-of-order HTTP parts but also to verify the known-length implementation.

Design Choices:

    - Buffer Reference: The output buffer is kept as a reference to optimize performance. Copying the entire buffer at the end of the serialization would be inefficient.
    - Inlining serializeContentChunk: I inlined the serializeContentChunk function to minimize overhead from function prologues and epilogues, as it is expected to be used frequently.
    - Buffers for Known-Length Format: For known-length formats, two buffers were introduced: chunkBuffer and fieldSectionBuffer. These buffers are used when the request/response consists of multiple parts. I did some researchs to find what could be the optimal initial capacities for those 2 buffers. I found out that I could set them to 500 and 700, respectively, based on data from the following sources:
        - SPDY Whitepaper for header field sizes: https://www.chromium.org/spdy/spdy-whitepaper
        - Arxiv paper on HTTP body size for body content size: https://arxiv.org/pdf/1405.2330 (If needed, I can provide more details on how these values were derived.) However, as underlined in the ByteBuffer implementation: https://github.com/apple/swift-nio/blob/main/Sources/NIOCore/ByteBuffer-core.swift, the initial capacity is set to: let newCapacity = capacity == 0 ? 0 : capacity.nextPowerOf2ClampedToMax() . Therefore, I decided to not use those values as it would very likely to be way too much. Given this, I decided not to use the predefined values, as they would likely be too large. Instead, I opted to rely on the initial size encountered when initializing the two buffers.
    - FSM Transition Definitions: The state transition definitions in the FSM are declared as static, with the intention that these definitions will be placed in the data section of the compiled binary. This should save memory but as I only used Swift for a couple of days now, I prefer to take distance. I tried to verify this by reviewing the assembly output here: https://godbolt.org/z/s88Kaxqn8 but I wasn't able to confirm with certainty due to the noise in the output.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
