### PR TITLE
Strict concurrency checking for ObliviousHTTP and ObliviousX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,24 @@
 
 import PackageDescription
 
+let strictConcurrencyDevelopment = false
+
+let strictConcurrencySettings: [SwiftSetting] = {
+    var initialSettings: [SwiftSetting] = []
+    initialSettings.append(contentsOf: [
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+
+    if strictConcurrencyDevelopment {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
+        initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
+    }
+
+    return initialSettings
+}()
+
 let package = Package(
     name: "swift-nio-oblivious-http",
     platforms: [
@@ -34,7 +52,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.54.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
     ],
     targets: [
@@ -43,13 +61,15 @@ let package = Package(
             dependencies: [
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .target(
             name: "ObliviousX",
             dependencies: [
                 .product(name: "Crypto", package: "swift-crypto")
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .testTarget(
             name: "ObliviousHTTPTests",
@@ -58,14 +78,16 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .testTarget(
             name: "ObliviousXTests",
             dependencies: [
                 "ObliviousX",
                 .product(name: "Crypto", package: "swift-crypto"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
     ]
 )

--- a/Sources/ObliviousHTTP/BHTTPParser.swift
+++ b/Sources/ObliviousHTTP/BHTTPParser.swift
@@ -15,7 +15,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Binary HTTP parser as described in [RFC9292](https://www.rfc-editor.org/rfc/rfc9292).
-public struct BHTTPParser {
+public struct BHTTPParser: Sendable {
     private var buffer: ByteBuffer?
     private var state: State
     private var role: Role
@@ -447,7 +447,7 @@ extension BHTTPParser {
     }
 
     /// Role to assume when parsing binary HTTP
-    public enum Role {
+    public enum Role: Sendable {
         case client
         case server
 
@@ -471,7 +471,7 @@ extension BHTTPParser {
     }
 
     /// Part of overall HTTP request or response.
-    public enum Message {
+    public enum Message: Sendable {
         case request(HTTPServerRequestPart)
         case response(HTTPClientResponsePart)
     }

--- a/Sources/ObliviousHTTP/BHTTPSerializer.swift
+++ b/Sources/ObliviousHTTP/BHTTPSerializer.swift
@@ -21,7 +21,7 @@ import NIOHTTP1
 // Later optimizations can be made by adding more state into this type.
 /// Binary HTTP serialiser as described in [RFC9292](https://www.rfc-editor.org/rfc/rfc9292).
 /// Currently only indeterminate-length encoding is supported.
-public struct BHTTPSerializer {
+public struct BHTTPSerializer: Sendable {
     /// Initialise a Binary HTTP Serialiser.
     public init() {}
 
@@ -96,7 +96,7 @@ public struct BHTTPSerializer {
 
 extension BHTTPSerializer {
     /// Types of message for binary http serilaisation
-    public enum Message {
+    public enum Message: Sendable {
         /// Part of an HTTP request.
         case request(HTTPClientRequestPart)
         /// Part of an HTTP response.

--- a/Sources/ObliviousX/OHTTPEncapsulation.swift
+++ b/Sources/ObliviousX/OHTTPEncapsulation.swift
@@ -11,13 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Crypto
+@preconcurrency import Crypto
 import Foundation
 
 /// Functionality to add oblivious HTTP style encapsulation to data messages.
 @available(macOS 14, iOS 17, *)
-public enum OHTTPEncapsulation {
-    /// Encapsulate a request messge.
+public enum OHTTPEncapsulation: Sendable {
+    /// Encapsulate a request message.
     /// - Parameters:
     ///   - keyID: Key Id to send.
     ///   - publicKey: Public key for the recipient.
@@ -47,7 +47,7 @@ public enum OHTTPEncapsulation {
     }
 
     /// Stream a request in multiple chunks.
-    public struct StreamingRequest {
+    public struct StreamingRequest: Sendable {
         /// Bytes representation of header.
         public let header: Data
         /// Sender used to seal messages.
@@ -127,7 +127,7 @@ public enum OHTTPEncapsulation {
     }
 
     /// Encapsulated request header.
-    public struct RequestHeader {
+    public struct RequestHeader: Sendable {
         /// Key Id specified.
         public private(set) var keyID: UInt8
 
@@ -148,7 +148,7 @@ public enum OHTTPEncapsulation {
     }
 
     /// Functionality to remove oblivious encapsulation from a series of request chunks.
-    public struct StreamingRequestDecapsulator {
+    public struct StreamingRequestDecapsulator: Sendable {
         /// The request header.
         public private(set) var header: RequestHeader
 
@@ -285,7 +285,7 @@ public enum OHTTPEncapsulation {
     }
 
     /// Processor for a series of response chunks.
-    public struct StreamingResponse {
+    public struct StreamingResponse: Sendable {
         private let responseNonce: Data
 
         private var aeadNonce: Data
@@ -380,7 +380,7 @@ public enum OHTTPEncapsulation {
     }
 
     /// Decapsulator which can process a response as a series of chunks.
-    public struct StreamingResponseDecapsulator {
+    public struct StreamingResponseDecapsulator: Sendable {
         enum State {
             case awaitingResponseNonce(
                 mediaType: String,
@@ -517,6 +517,8 @@ public enum OHTTPEncapsulation {
         return info
     }
 }
+
+extension OHTTPEncapsulation.RequestDecapsulator: Sendable where Bytes: Sendable {}
 
 extension RandomAccessCollection where Element == UInt8, Self == Self.SubSequence {
     mutating func popUInt8() -> UInt8? {


### PR DESCRIPTION
Motivation:

To increase concurrency safety the ObliviousHTTP and ObliviousX modules should compile without warning under strict concurrency checking.

Modifications:

- Add explicit Sendable annotations
- Add `@preconcurrency` to the `Crpto` import as it's not yet concurrency clean.

Result:

No concurrency warnings.