### PR TITLE
Added require-explicit-sendable to macOS CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,5 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-nio-oblivious-http-Package
+      xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+      xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,3 +36,5 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-nio-oblivious-http-Package
+      xcode_16_2_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+      xcode_16_3_build_arguments_override: "-Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"


### PR DESCRIPTION
Added require-explicit-sendable to macOS CI

### Motivation:

Make macOS CI fail in case we have public types not explicitly marked as Sendable or explicitly marked as non sendable.

### Modifications:

Enabled extra flags to macOS CI build.

### Result:

Swift compiler will check for public types without an explicit Sendable statement.
